### PR TITLE
fix: validate graph/schema context in direct API, reset context on drop

### DIFF
--- a/crates/bindings/c/src/database.rs
+++ b/crates/bindings/c/src/database.rs
@@ -703,7 +703,10 @@ pub extern "C" fn grafeo_set_schema(db: *mut GrafeoDatabase, name: *const c_char
         set_last_error("Invalid UTF-8 in schema name");
         return GrafeoStatus::ErrorInvalidUtf8;
     };
-    db.inner.read().set_current_schema(Some(name_str));
+    if let Err(e) = db.inner.read().set_current_schema(Some(name_str)) {
+        set_last_error(&e.to_string());
+        return GrafeoStatus::ErrorQuery;
+    }
     GrafeoStatus::Ok
 }
 
@@ -721,7 +724,7 @@ pub extern "C" fn grafeo_reset_schema(db: *mut GrafeoDatabase) -> GrafeoStatus {
     }
     // SAFETY: Caller guarantees valid pointer.
     let db = unsafe { &*db };
-    db.inner.read().set_current_schema(None);
+    let _ = db.inner.read().set_current_schema(None);
     GrafeoStatus::Ok
 }
 

--- a/crates/bindings/node/src/database.rs
+++ b/crates/bindings/node/src/database.rs
@@ -499,8 +499,11 @@ impl JsGrafeoDB {
     /// Equivalent to running `SESSION SET SCHEMA <name>` but persists across
     /// calls. Use `resetSchema()` to clear it.
     #[napi(js_name = "setSchema")]
-    pub fn set_schema(&self, name: String) {
-        self.inner.read().set_current_schema(Some(&name));
+    pub fn set_schema(&self, name: String) -> napi::Result<()> {
+        self.inner
+            .read()
+            .set_current_schema(Some(&name))
+            .map_err(|e| napi::Error::from_reason(e.to_string()))
     }
 
     /// Clears the current schema context.
@@ -508,7 +511,7 @@ impl JsGrafeoDB {
     /// Subsequent `execute()` calls will use the default (no-schema) namespace.
     #[napi(js_name = "resetSchema")]
     pub fn reset_schema(&self) {
-        self.inner.read().set_current_schema(None);
+        let _ = self.inner.read().set_current_schema(None);
     }
 
     /// Returns the current schema name, or `null` if no schema is set.

--- a/crates/bindings/python/src/database.rs
+++ b/crates/bindings/python/src/database.rs
@@ -2550,15 +2550,19 @@ impl PyGrafeoDB {
     /// Example:
     ///     db.set_schema("reporting")
     ///     result = db.execute("SHOW GRAPH TYPES")  # only sees types in 'reporting'
-    fn set_schema(&self, name: String) {
-        self.inner.read().set_current_schema(Some(&name));
+    fn set_schema(&self, name: String) -> PyResult<()> {
+        self.inner
+            .read()
+            .set_current_schema(Some(&name))
+            .map_err(PyGrafeoError::from)?;
+        Ok(())
     }
 
     /// Clears the current schema context.
     ///
     /// Subsequent `execute()` calls will use the default (no-schema) namespace.
     fn reset_schema(&self) {
-        self.inner.read().set_current_schema(None);
+        let _ = self.inner.read().set_current_schema(None);
     }
 
     /// Returns the current schema name, or `None` if no schema is set.

--- a/crates/bindings/wasm/src/lib.rs
+++ b/crates/bindings/wasm/src/lib.rs
@@ -1049,13 +1049,19 @@ impl Database {
     /// Equivalent to `SESSION SET SCHEMA name` but persists across calls.
     /// Call `resetSchema()` to clear it.
     ///
+    /// # Errors
+    ///
+    /// Returns an error if the schema does not exist.
+    ///
     /// ```js
     /// db.setSchema("reporting");
     /// const types = db.execute("SHOW GRAPH TYPES"); // only sees 'reporting' types
     /// ```
     #[wasm_bindgen(js_name = "setSchema")]
-    pub fn set_schema(&self, name: &str) {
-        self.inner.set_current_schema(Some(name));
+    pub fn set_schema(&self, name: &str) -> Result<(), JsValue> {
+        self.inner
+            .set_current_schema(Some(name))
+            .map_err(|e| JsValue::from_str(&e.to_string()))
     }
 
     /// Clears the current schema context.
@@ -1063,7 +1069,7 @@ impl Database {
     /// Subsequent `execute()` calls will use the default (no-schema) namespace.
     #[wasm_bindgen(js_name = "resetSchema")]
     pub fn reset_schema(&self) {
-        self.inner.set_current_schema(None);
+        let _ = self.inner.set_current_schema(None);
     }
 
     /// Returns the current schema name, or `undefined` if no schema is set.

--- a/crates/grafeo-engine/src/database/mod.rs
+++ b/crates/grafeo-engine/src/database/mod.rs
@@ -46,7 +46,7 @@ use grafeo_adapters::storage::wal::{
     DurabilityMode as WalDurabilityMode, LpgWal, WalConfig, WalRecord, WalRecovery,
 };
 use grafeo_common::memory::buffer::{BufferManager, BufferManagerConfig};
-use grafeo_common::utils::error::Result;
+use grafeo_common::utils::error::{Error, QueryError, QueryErrorKind, Result};
 use grafeo_core::graph::lpg::LpgStore;
 #[cfg(feature = "rdf")]
 use grafeo_core::graph::rdf::RdfStore;
@@ -1207,8 +1207,22 @@ impl GrafeoDB {
     ///
     /// This is equivalent to running `USE GRAPH <name>` but without creating a session.
     /// Pass `None` to reset to the default graph.
-    pub fn set_current_graph(&self, name: Option<&str>) {
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the named graph does not exist.
+    pub fn set_current_graph(&self, name: Option<&str>) -> Result<()> {
+        if let Some(name) = name
+            && !name.eq_ignore_ascii_case("default")
+            && self.lpg_store().graph(name).is_none()
+        {
+            return Err(Error::Query(QueryError::new(
+                QueryErrorKind::Semantic,
+                format!("Graph '{name}' does not exist"),
+            )));
+        }
         *self.current_graph.write() = name.map(ToString::to_string);
+        Ok(())
     }
 
     /// Returns the current schema name, if any.
@@ -1224,8 +1238,21 @@ impl GrafeoDB {
     ///
     /// This is equivalent to running `SESSION SET SCHEMA <name>` but without creating
     /// a session. Pass `None` to clear the schema context.
-    pub fn set_current_schema(&self, name: Option<&str>) {
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the named schema does not exist.
+    pub fn set_current_schema(&self, name: Option<&str>) -> Result<()> {
+        if let Some(name) = name
+            && !self.catalog.schema_exists(name)
+        {
+            return Err(Error::Query(QueryError::new(
+                QueryErrorKind::Semantic,
+                format!("Schema '{name}' does not exist"),
+            )));
+        }
         *self.current_schema.write() = name.map(ToString::to_string);
+        Ok(())
     }
 
     /// Returns the adaptive execution configuration.
@@ -1340,8 +1367,21 @@ impl GrafeoDB {
     }
 
     /// Drops a named graph. Returns `true` if dropped, `false` if it did not exist.
+    ///
+    /// If the dropped graph was the active graph context, the context is reset
+    /// to the default graph.
     pub fn drop_graph(&self, name: &str) -> bool {
-        self.lpg_store().drop_graph(name)
+        let dropped = self.lpg_store().drop_graph(name);
+        if dropped {
+            let mut current = self.current_graph.write();
+            if current
+                .as_deref()
+                .is_some_and(|g| g.eq_ignore_ascii_case(name))
+            {
+                *current = None;
+            }
+        }
+        dropped
     }
 
     /// Returns all named graph names.

--- a/crates/grafeo-engine/tests/lpg_graph_isolation.rs
+++ b/crates/grafeo-engine/tests/lpg_graph_isolation.rs
@@ -521,10 +521,10 @@ fn db_current_graph_api() {
     db.execute("USE GRAPH mydb").unwrap();
     assert_eq!(db.current_graph(), Some("mydb".to_string()));
 
-    db.set_current_graph(None);
+    db.set_current_graph(None).unwrap();
     assert_eq!(db.current_graph(), None);
 
-    db.set_current_graph(Some("mydb"));
+    db.set_current_graph(Some("mydb")).unwrap();
     assert_eq!(db.current_graph(), Some("mydb".to_string()));
 }
 

--- a/crates/grafeo-engine/tests/lpg_graph_isolation.rs
+++ b/crates/grafeo-engine/tests/lpg_graph_isolation.rs
@@ -529,6 +529,80 @@ fn db_current_graph_api() {
 }
 
 #[test]
+fn set_current_graph_rejects_nonexistent() {
+    let db = db();
+    let err = db.set_current_graph(Some("nope")).unwrap_err();
+    assert!(
+        err.to_string().contains("does not exist"),
+        "expected 'does not exist' error, got: {err}"
+    );
+    // context should remain unchanged
+    assert_eq!(db.current_graph(), None);
+}
+
+#[test]
+fn set_current_graph_allows_default() {
+    let db = db();
+    // "default" is always valid even without creating it
+    db.set_current_graph(Some("default")).unwrap();
+    // setting None clears it
+    db.set_current_graph(None).unwrap();
+    assert_eq!(db.current_graph(), None);
+}
+
+#[test]
+fn drop_graph_resets_active_context() {
+    let db = db();
+    db.execute("CREATE GRAPH ephemeral").unwrap();
+    db.set_current_graph(Some("ephemeral")).unwrap();
+    assert_eq!(db.current_graph(), Some("ephemeral".to_string()));
+
+    db.drop_graph("ephemeral");
+    assert_eq!(
+        db.current_graph(),
+        None,
+        "current_graph should reset after dropping the active graph"
+    );
+}
+
+#[test]
+fn drop_graph_preserves_context_for_other_graph() {
+    let db = db();
+    db.execute("CREATE GRAPH keep").unwrap();
+    db.execute("CREATE GRAPH other").unwrap();
+    db.set_current_graph(Some("keep")).unwrap();
+
+    db.drop_graph("other");
+    assert_eq!(
+        db.current_graph(),
+        Some("keep".to_string()),
+        "dropping a different graph should not touch current_graph"
+    );
+}
+
+#[test]
+fn set_current_schema_rejects_nonexistent() {
+    let db = db();
+    let err = db.set_current_schema(Some("fake")).unwrap_err();
+    assert!(
+        err.to_string().contains("does not exist"),
+        "expected 'does not exist' error, got: {err}"
+    );
+    assert_eq!(db.current_schema(), None);
+}
+
+#[test]
+fn set_current_schema_accepts_valid() {
+    let db = db();
+    db.execute("CREATE SCHEMA reporting").unwrap();
+    db.set_current_schema(Some("reporting")).unwrap();
+    assert_eq!(db.current_schema(), Some("reporting".to_string()));
+
+    db.set_current_schema(None).unwrap();
+    assert_eq!(db.current_schema(), None);
+}
+
+#[test]
 fn db_execute_two_named_graphs_independent() {
     let db = db();
     db.execute("CREATE GRAPH alpha").unwrap();


### PR DESCRIPTION
Closes #6.

`drop_graph`, `set_current_graph`, and `set_current_schema` on `GrafeoDB` skip the safety checks that the Cypher layer enforces. cubic flagged this in [#243](https://github.com/GrafeoDB/grafeo/pull/243#discussion_r3048472540).

- `drop_graph` now resets `current_graph` when the active graph is dropped
- `set_current_graph` now validates the graph exists, returns `Result<()>`
- `set_current_schema` now validates the schema exists, returns `Result<()>`

The last two are breaking. 2 call sites in engine tests, 8 across bindings (Python, C, Node, WASM). All updated here.